### PR TITLE
Fix warnings when compiling against FTD2XX

### DIFF
--- a/exSID_ftdiwrap.c
+++ b/exSID_ftdiwrap.c
@@ -110,8 +110,8 @@ static int (* _ftdi_usb_open_desc)(void *, int, int, const char *, const char *)
 
 // callbacks for FTD2XX
 #ifdef	HAVE_FTD2XX
-static int (*_FT_Write)(void *, LPVOID, int, unsigned int *);
-static int (*_FT_Read)(void *, LPVOID, int, unsigned int *);
+static int (*_FT_Write)(void *, LPVOID, int, LPDWORD);
+static int (*_FT_Read)(void *, LPVOID, int, LPDWORD);
 static int (*_FT_OpenEx)(const char *, int, void **);
 static int (*_FT_ResetDevice)(void *);
 static int (*_FT_SetBaudRate)(void *, int);


### PR DESCRIPTION
I see these warnings when compiling on MinGW64 with the ftd2xx header:

```
In file included from exSID_ftdiwrap.c:19:
exSID_ftdiwrap.c: In function '_xSfwFT_write_data':
exSID_ftdiwrap.c:138:56: warning: passing argument 4 of '_FT_Write' from incompatible pointer type [-Wincompatible-pointer-types]
  138 |  if(unlikely(rval = _FT_Write(ftdi, (LPVOID)buf, size, &dummysize)))
      |                                                        ^~~~~~~~~~
      |                                                        |
      |                                                        DWORD * {aka long unsigned int *}
exSID_defs.h:107:46: note: in definition of macro 'unlikely'
  107 |  #define unlikely(x)     __builtin_expect(!!(x), 0)
      |                                              ^
exSID_ftdiwrap.c:138:56: note: expected 'unsigned int *' but argument is of type 'DWORD *' {aka 'long unsigned int *'}
  138 |  if(unlikely(rval = _FT_Write(ftdi, (LPVOID)buf, size, &dummysize)))
      |                                                        ^~~~~~~~~~
exSID_defs.h:107:46: note: in definition of macro 'unlikely'
  107 |  #define unlikely(x)     __builtin_expect(!!(x), 0)
      |                                              ^
exSID_ftdiwrap.c: In function '_xSfwFT_read_data':
exSID_ftdiwrap.c:148:56: warning: passing argument 4 of '_FT_Read' from incompatible pointer type [-Wincompatible-pointer-types]
  148 |  if (unlikely(rval = _FT_Read(ftdi, (LPVOID)buf, size, &dummysize)))
      |                                                        ^~~~~~~~~~
      |                                                        |
      |                                                        DWORD * {aka long unsigned int *}
exSID_defs.h:107:46: note: in definition of macro 'unlikely'
  107 |  #define unlikely(x)     __builtin_expect(!!(x), 0)
      |                                              ^
exSID_ftdiwrap.c:148:56: note: expected 'unsigned int *' but argument is of type 'DWORD *' {aka 'long unsigned int *'}
  148 |  if (unlikely(rval = _FT_Read(ftdi, (LPVOID)buf, size, &dummysize)))
      |                                                        ^~~~~~~~~~
exSID_defs.h:107:46: note: in definition of macro 'unlikely'
  107 |  #define unlikely(x)     __builtin_expect(!!(x), 0)
      |                                              ^
```
