### PR TITLE
Remove unneeded argument (#4)

### DIFF
--- a/exSID_ftdiwrap.c
+++ b/exSID_ftdiwrap.c
@@ -252,7 +252,7 @@ int xSfw_dlopen()
 dlfail:
 	xsdbg("dlsym error: %s", dlerrorstr);
 	_xSfw_free_errstr(dlerrorstr);
-	xSfw_dlclose(dlhandle);
+	xSfw_dlclose();
 	return -1;
 }
 


### PR DESCRIPTION
It doesn't error out here but the call is indeed wrong.